### PR TITLE
feat: foreign_key optional syntax

### DIFF
--- a/KuneiformLexer.g4
+++ b/KuneiformLexer.g4
@@ -38,7 +38,9 @@ UNIQUE_:   'unique';
 INDEX_:    'index';
 //// foreign key
 FOREIGN_KEY_:           'foreign_key';
+FOREIGN_KEY_ABBR_:      'fk';
 REFERENCES_:            'references';
+REFERENCES_ABBR_:       'ref';
 ACTION_ON_UPDATE_:      'on_update';
 ACTION_ON_DELETE_:      'on_delete';
 ACTION_DO_:             'do';

--- a/KuneiformParser.g4
+++ b/KuneiformParser.g4
@@ -76,7 +76,7 @@ index_def_list:
 
 foreign_key_action:
     (ACTION_ON_UPDATE_ | ACTION_ON_DELETE_)
-    ACTION_DO_
+    ACTION_DO_?
     (ACTION_DO_NO_ACTION_
     | ACTION_DO_RESTRICT_
     | ACTION_DO_SET_NULL_
@@ -85,9 +85,10 @@ foreign_key_action:
 ;
 
 foreign_key_def:
-    FOREIGN_KEY_
+    (FOREIGN_KEY_ | FOREIGN_KEY_ABBR_)
     L_PAREN column_name_list R_PAREN
-    REFERENCES_ table_name
+    (REFERENCES_ | REFERENCES_ABBR_)
+    table_name
     L_PAREN column_name_list R_PAREN
     foreign_key_action*
 ;


### PR DESCRIPTION
An optional syntax to define foreign key kwilteam/kuneiform#4 :

Before: `foreign_key (tc1) references tt1 (tc1) on_update do no_action`
Now: `fk (tc1) ref tt1 (tc1) on_update no_action`