### PR TITLE
fix order for index and fk

### DIFF
--- a/KuneiformParser.g4
+++ b/KuneiformParser.g4
@@ -25,8 +25,7 @@ table_decl:
     TABLE_ table_name
     L_BRACE
     column_def_list
-    (COMMA index_def_list)?
-    (COMMA foreign_key_def_list)?
+    (COMMA (index_def | foreign_key_def))*
     COMMA? // optional comma
     R_BRACE
 ;
@@ -70,10 +69,6 @@ index_def:
     L_PAREN column_name_list R_PAREN
 ;
 
-index_def_list:
-    index_def (COMMA index_def)*
-;
-
 foreign_key_action:
     (ACTION_ON_UPDATE_ | ACTION_ON_DELETE_)
     ACTION_DO_?
@@ -91,10 +86,6 @@ foreign_key_def:
     table_name
     L_PAREN column_name_list R_PAREN
     foreign_key_action*
-;
-
-foreign_key_def_list:
-    foreign_key_def (COMMA foreign_key_def)*
 ;
 
 action_decl:


### PR DESCRIPTION
This will cause error:
```
table t1{
    fk ..,
    index ...,
}
```
Reason: in syntax, the index_def_list will be parsed before fk_def_list

This pr adjust syntax to allow write fk and index in mixed order