### PR TITLE
feat: remove lexical mode

### DIFF
--- a/KuneiformLexer.g4
+++ b/KuneiformLexer.g4
@@ -15,6 +15,9 @@ R_BRACE:   '}';
 COMMA:     ',';
 DOLLAR:    '$';
 HASH:      '#';
+AT:        '@';
+PERIOD:    '.';
+EQ:        '=';
 
 // keywords
 DATABASE_: 'database';
@@ -22,11 +25,11 @@ USE_:      'use';
 AS_:       'as';
 TABLE_:    'table';
 ACTION_:   'action';
+INIT_:     'init';
 PUBLIC_:   'public';
 PRIVATE_:  'private';
 VIEW_:     'view';
 MUSTSIGN_: 'mustsign';
-INIT_:     'init';
 //// column type
 INT_:      'int';
 TEXT_:     'text';
@@ -60,17 +63,14 @@ UPDATE_:   [uU][pP][dD][aA][tT][eE];
 DELETE_:   [dD][eE][lL][eE][tT][eE];
 WITH_:     [wW][iI][tT][hH]        ;
 
-//// switch to ACTION_MODE
-ACTION_OPEN: (PUBLIC_|PRIVATE_) (WSNL+ VIEW_ WSNL+ MUSTSIGN_?)? WSNL* L_BRACE -> mode(ACTION_MODE);
-INIT_OPEN: INIT_ WSNL* L_PAREN WSNL* R_PAREN WSNL* L_BRACE -> mode(ACTION_MODE);
-
 // literals
 IDENTIFIER:
     [a-zA-Z] [a-zA-Z_0-9]*
 ;
 
 INDEX_NAME: HASH IDENTIFIER;
-PARAMETER: DOLLAR IDENTIFIER;
+PARAM_OR_VAR: DOLLAR IDENTIFIER;
+BLOCK_VAR: AT IDENTIFIER;
 
 UNSIGNED_NUMBER_LITERAL:
     DIGIT+
@@ -84,6 +84,9 @@ STRING_LITERAL:
     DOUBLE_QUOTE_STRING
     | SINGLE_QUOTE_STRING
 ;
+
+SQL_KEYWORDS: SELECT_ | INSERT_ | UPDATE_ | DELETE_ | WITH_;
+SQL_STMT: SQL_KEYWORDS WSNL+ ~[;}]+;
 
 WS:            [ \t]        -> channel(HIDDEN);
 TERMINATOR:    [\r\n]       -> channel(HIDDEN);
@@ -100,37 +103,3 @@ fragment SINGLE_QUOTE_STRING_CHAR: ~['\r\n\\] | ('\\' .);
 fragment DOUBLE_QUOTE_STRING: '"' DOUBLE_QUOTE_STRING_CHAR* '"';
 fragment SINGLE_QUOTE_STRING: '\'' SINGLE_QUOTE_STRING_CHAR* '\'';
 
-
-// ----------------- ACTION_MODE -----------------
-mode ACTION_MODE;
-ACTION_CLOSE: R_BRACE -> mode(DEFAULT_MODE);
-
-EQ:         '=';
-PLUS:       '+';
-PERIOD:     '.';
-A_COMMA:    COMMA;
-A_DOLLAR:   DOLLAR;
-A_AT:       '@';
-A_L_PAREN:  L_PAREN;
-A_R_PAREN:  R_PAREN;
-A_STMT_END: SCOL;
-
-SQL_KEYWORDS: SELECT_ | INSERT_ | UPDATE_ | DELETE_ | WITH_;
-
-A_IDENTIFIER: IDENTIFIER;
-A_VARIABLE: A_DOLLAR A_IDENTIFIER;
-A_REF: A_AT A_IDENTIFIER;
-A_UNSIGNED_NUMBER_LITERAL: UNSIGNED_NUMBER_LITERAL;
-A_SIGNED_NUMBER_LITERAL: SIGNED_NUMBER_LITERAL;
-A_STRING_LITERAL: STRING_LITERAL;
-
-// we only need sql statement as a whole, sql-parser will parse it
-A_SQL_STMT: SQL_KEYWORDS ~[;}]+;
-
-A_WS:            WS -> channel(HIDDEN);
-A_TERMINATOR:    TERMINATOR -> channel(HIDDEN);
-A_BLOCK_COMMENT: BLOCK_COMMENT -> channel(HIDDEN);
-A_LINE_COMMENT:  LINE_COMMENT -> channel(HIDDEN);
-
-// if not enforce syntax on call stmt, use this for action_stmt instead
-//ACTION_STMT: ~[;}]+;

--- a/KuneiformParser.g4
+++ b/KuneiformParser.g4
@@ -99,16 +99,38 @@ foreign_key_def:
     foreign_key_action*
 ;
 
+action_visibility:
+    PUBLIC_
+    | PRIVATE_
+;
+
+action_mutability:
+    VIEW_
+;
+
+action_auxiliary:
+    MUSTSIGN_
+;
+
+action_attr_list:
+    (action_visibility | action_mutability | action_auxiliary)*
+;
+
 action_decl:
     ACTION_ action_name
     L_PAREN param_list R_PAREN
-    ACTION_OPEN
+    action_attr_list
+    L_BRACE
     action_stmt_list
-    ACTION_CLOSE
+    R_BRACE
 ;
 
 param_list:
-    PARAMETER? (COMMA PARAMETER)*
+    parameter? (COMMA parameter)*
+;
+
+parameter:
+    PARAM_OR_VAR
 ;
 
 database_name:
@@ -149,63 +171,62 @@ ext_config_value:
 
 // parsed as action
 init_decl:
-    INIT_OPEN
+    INIT_
+    L_PAREN R_PAREN
+    L_BRACE
     action_stmt_list
-    ACTION_CLOSE
+    R_BRACE
 ;
-
-// --------- action statements ---------
-// only for enforing syntax, won't actually parse
 
 action_stmt_list:
     action_stmt+
 ;
 
 action_stmt:
-    a_sql_stmt
-    | a_call_stmt
+    sql_stmt
+    | call_stmt
 ;
 
-a_sql_stmt:
-    A_SQL_STMT A_STMT_END
+sql_stmt:
+    SQL_STMT SCOL
 ;
 
-a_variable_name:
-    A_VARIABLE
+variable:
+    PARAM_OR_VAR
 ;
 
-a_block_variable_name:
-    A_REF
+block_var:
+    BLOCK_VAR
 ;
 
-a_literal_value:
-    A_STRING_LITERAL
-    | A_UNSIGNED_NUMBER_LITERAL
+ext_call_name:
+    IDENTIFIER (PERIOD IDENTIFIER)?
 ;
 
-a_fn_name:
-    A_IDENTIFIER (PERIOD A_IDENTIFIER)?
+callee_name:
+    ext_call_name
+    | action_name
 ;
 
-a_call_receivers:
-    a_variable_name (A_COMMA a_variable_name)*
+call_receivers:
+    variable (COMMA variable)*
 ;
 
-a_call_stmt:
-    (a_call_receivers EQ)?
-    a_call_body  A_STMT_END
+call_stmt:
+    (call_receivers EQ)?
+    call_body SCOL
 ;
 
-a_call_body:
-    a_fn_name A_L_PAREN a_fn_arg_list A_R_PAREN
+call_body:
+    callee_name L_PAREN fn_arg_list R_PAREN
 ;
 
-a_fn_arg_list:
-    a_fn_arg? (A_COMMA a_fn_arg)*
+fn_arg_list:
+    fn_arg? (COMMA fn_arg)*
 ;
 
-a_fn_arg:
-    a_literal_value
-    | a_variable_name
-    | a_block_variable_name
+fn_arg:
+    literal_value
+    | variable
+    | block_var
 ;


### PR DESCRIPTION
remove extra lexical mode `action_mode`.

We might need it if the rules get more complex, better separation, each lexical mode will cater to one concern, one different set of rules, i made a [branch](https://github.com/kwilteam/kuneiform-grammar/tree/feature/action-attr-mode) demostrate this since we don't have a clear sentinels for action