### PR TITLE
feat: add owner auxiliary

### DIFF
--- a/KuneiformLexer.g4
+++ b/KuneiformLexer.g4
@@ -30,6 +30,7 @@ PUBLIC_:   'public';
 PRIVATE_:  'private';
 VIEW_:     'view';
 MUSTSIGN_: 'mustsign';
+OWNER_:    'owner';
 //// column type
 INT_:      'int';
 TEXT_:     'text';

--- a/KuneiformParser.g4
+++ b/KuneiformParser.g4
@@ -110,6 +110,7 @@ action_mutability:
 
 action_auxiliary:
     MUSTSIGN_
+    | OWNER_
 ;
 
 action_attr_list:


### PR DESCRIPTION
According to kwilteam/kwil-db#160, add a new auxiliary `owner`, which specify that caller of the action need to be the owner of the database