### PR TITLE
Feature/sql scalar function

### DIFF
--- a/KuneiformLexer.g4
+++ b/KuneiformLexer.g4
@@ -17,7 +17,29 @@ DOLLAR:    '$';
 HASH:      '#';
 AT:        '@';
 PERIOD:    '.';
-EQ:        '=';
+ASSIGN:    '=';
+//// sql scalar function expressions symbols
+//// probably a different Lexical mode is a good idea
+PLUS:      '+';
+MINUS:     '-';
+STAR:      '*';
+DIV:       '/';
+MOD:       '%';
+TILDE:     '~';
+PIPE2:     '||';
+LT2:       '<<';
+GT2:       '>>';
+AMP:       '&';
+PIPE:      '|';
+EQ:        '==';
+LT:        '<';
+LT_EQ:     '<=';
+GT:        '>';
+GT_EQ:     '>=';
+SQL_NOT_EQ1: '!=';
+SQL_NOT_EQ2: '<>';
+////
+
 
 // keywords
 DATABASE_: 'database';
@@ -58,12 +80,18 @@ ACTION_DO_CASCADE_:     'cascade';
 ACTION_DO_SET_NULL_:    'set_null';
 ACTION_DO_SET_DEFAULT_: 'set_default';
 ACTION_DO_RESTRICT_:    'restrict';
-// sql keywords (make it top level keywords)
+//// sql keywords (make it top level keywords)
 SELECT_:   [sS][eE][lL][eE][cC][tT];
 INSERT_:   [iI][nN][sS][eE][rR][tT];
 UPDATE_:   [uU][pP][dD][aA][tT][eE];
 DELETE_:   [dD][eE][lL][eE][tT][eE];
 WITH_:     [wW][iI][tT][hH]        ;
+//// scalar functions expressions keyworkds
+//// probably a different Lexical mode is a good idea
+NOT_: 'not';
+AND_: 'and';
+OR_:  'or';
+////
 
 // literals
 IDENTIFIER:

--- a/KuneiformParser.g4
+++ b/KuneiformParser.g4
@@ -193,6 +193,19 @@ sql_stmt:
     SQL_STMT SCOL
 ;
 
+call_stmt:
+    (call_receivers EQ)?
+    call_body SCOL
+;
+
+call_receivers:
+    variable (COMMA variable)*
+;
+
+call_body:
+    fn_name L_PAREN fn_arg_list R_PAREN
+;
+
 variable:
     PARAM_OR_VAR
 ;
@@ -201,34 +214,51 @@ block_var:
     BLOCK_VAR
 ;
 
-ext_call_name:
+extension_call_name:
     IDENTIFIER PERIOD IDENTIFIER
 ;
 
-callee_name:
-    ext_call_name
+//external_action_name:
+//    IDENTIFIER PERIOD IDENTIFIER
+//;
+
+// function name
+fn_name:
+    extension_call_name
     | action_name
+//    | external_action_name
 ;
 
-call_receivers:
-    variable (COMMA variable)*
+// (inside action) scalar function name
+sfn_name:
+    IDENTIFIER
 ;
 
-call_stmt:
-    (call_receivers EQ)?
-    call_body SCOL
-;
-
-call_body:
-    callee_name L_PAREN fn_arg_list R_PAREN
-;
+//fn_arg:
+//    literal_value
+//    | variable
+//    | block_var
+//;
 
 fn_arg_list:
-    fn_arg? (COMMA fn_arg)*
+//    fn_arg? (COMMA fn_arg)*
+    fn_arg_expr? (COMMA fn_arg_expr)*
 ;
 
-fn_arg:
+// NOTE: this will only be used inside fn_arg_list
+// precedence: highest to lowest
+fn_arg_expr:
     literal_value
     | variable
     | block_var
+    | sfn_name L_PAREN fn_arg_expr? (COMMA fn_arg_expr)* R_PAREN
 ;
+
+// future expr, replace whole `call_body`
+//expr:
+//    literal_value
+//    | variable_name
+//    | L_PAREN elevate_expr=expr R_PAREN
+//    | expr PLUS expr
+//    | function_name L_PAREN expr? (COMMA expr)* R_PAREN
+//;


### PR DESCRIPTION
Based on kwilteam/kuneiform#36
This pr changes `fn_args` to `fn_arg_expr` to support more functionalities, plus enables a set of new lexical tokens that could be used in `fn_arg_expr`.

Those tokens are:
- `+`
- `-`
- `*`
- `/`
- `%`
- `~`
- `||`
- `<<`
- `>>`
- `&`
- `|`
- `==`
- `<`
- `<=`
- `>`
- `>=`
- `!=`
- `<>`
- `not`
- `and`
- `or`